### PR TITLE
 Use GLPI temp dir during PDF generation

### DIFF
--- a/inc/barcode.class.php
+++ b/inc/barcode.class.php
@@ -301,6 +301,7 @@ class PluginBarcodeBarcode {
       $config = $pbConfig->getConfigType($type);
 
       $pdf= new Cezpdf($size, $orientation);
+      $pdf->tempPath = GLPI_TMP_DIR;
       $pdf->selectFont(GLPI_ROOT."/plugins/barcode/lib/ezpdf/fonts/Helvetica.afm");
       $pdf->ezStartPageNumbers($pdf->ez['pageWidth']-30, 10, 10, 'left', '{PAGENUM} / {TOTALPAGENUM}').
       $width   = $config['maxCodeWidth'];


### PR DESCRIPTION
PR #30 is included here as we need an updated version of `rospdf/pdf-php` in able to define the tmp dir used by `Cezpdf` class.