### PR TITLE
Base ability to generate Bar/QR codes on items fields

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -48,12 +48,6 @@ function plugin_barcode_MassiveActions($itemtype) {
    $generate_qrcode_action  = 'PluginBarcodeQRcode' . MassiveAction::CLASS_ACTION_SEPARATOR . 'Generate';
    $generate_qrcode_label   = __('Barcode', 'barcode')." - ".__('Print QRcodes', 'barcode');
 
-   if (Ticket::class === $itemtype) {
-      return [
-         $generate_barcode_action => $generate_barcode_label
-      ];
-   }
-
    if (!is_a($itemtype, CommonDBTM::class, true)) {
       return [];
    }
@@ -62,6 +56,12 @@ function plugin_barcode_MassiveActions($itemtype) {
       // QR code is always available as it contains ID field value
       $generate_qrcode_action => $generate_qrcode_label,
    ];
+
+   if (Ticket::class === $itemtype) {
+      // Ticket specific case, barcode is generated based on ticket ID
+      $actions[$generate_barcode_action] = $generate_barcode_label;
+   }
+
 
    /** @var CommonDBTM $item */
    $item = new $itemtype();

--- a/hook.php
+++ b/hook.php
@@ -62,7 +62,6 @@ function plugin_barcode_MassiveActions($itemtype) {
       $actions[$generate_barcode_action] = $generate_barcode_label;
    }
 
-
    /** @var CommonDBTM $item */
    $item = new $itemtype();
    $item->getEmpty();

--- a/hook.php
+++ b/hook.php
@@ -57,8 +57,8 @@ function plugin_barcode_MassiveActions($itemtype) {
       $generate_qrcode_action => $generate_qrcode_label,
    ];
 
-   if (Ticket::class === $itemtype) {
-      // Ticket specific case, barcode is generated based on ticket ID
+   if (is_a($itemtype, CommonITILObject::class, true)) {
+      // CommonITILObject specific case, barcode is generated based on ticket ID
       $actions[$generate_barcode_action] = $generate_barcode_label;
    }
 

--- a/hook.php
+++ b/hook.php
@@ -40,28 +40,39 @@
  */
 
 // Define actions :
-function plugin_barcode_MassiveActions($type) {
+function plugin_barcode_MassiveActions($itemtype) {
 
-   switch ($type) {
-      // New action for core and other plugin types : name = plugin_PLUGINNAME_actionname
-      case 'Computer' :
-      case 'Monitor' :
-      case 'Networking' :
-      case 'Printer' :
-      case 'Peripheral' :
-      case 'Phone' :
-         return ["PluginBarcodeBarcode".MassiveAction::CLASS_ACTION_SEPARATOR.'Generate'
-                    => __('Barcode', 'barcode')." - ".__('Print barcodes', 'barcode'),
-                 "PluginBarcodeQRcode".MassiveAction::CLASS_ACTION_SEPARATOR.'Generate'
-                    => __('Barcode', 'barcode')." - ".__('Print QRcodes', 'barcode')
-                ];
+   $generate_barcode_action = 'PluginBarcodeBarcode' . MassiveAction::CLASS_ACTION_SEPARATOR . 'Generate';
+   $generate_barcode_label  = __('Barcode', 'barcode')." - ".__('Print barcodes', 'barcode');
 
-      case 'Ticket' :
-         return ["PluginBarcodeBarcode".MassiveAction::CLASS_ACTION_SEPARATOR.'Generate'
-                   => __('Barcode', 'barcode')." - ".__('Print barcodes', 'barcode')
-                ];
+   $generate_qrcode_action  = 'PluginBarcodeQRcode' . MassiveAction::CLASS_ACTION_SEPARATOR . 'Generate';
+   $generate_qrcode_label   = __('Barcode', 'barcode')." - ".__('Print QRcodes', 'barcode');
+
+   if (Ticket::class === $itemtype) {
+      return [
+         $generate_barcode_action => $generate_barcode_label
+      ];
    }
-   return [];
+
+   if (!is_a($itemtype, CommonDBTM::class, true)) {
+      return [];
+   }
+
+   $actions = [
+      // QR code is always available as it contains ID field value
+      $generate_qrcode_action => $generate_qrcode_label,
+   ];
+
+   /** @var CommonDBTM $item */
+   $item = new $itemtype();
+   $item->getEmpty();
+
+   if (array_key_exists('otherserial', $item->fields)) {
+      // Barcode is based on otherserial field value
+      $actions[$generate_barcode_action] = $generate_barcode_label;
+   }
+
+   return $actions;
 }
 
 

--- a/inc/barcode.class.php
+++ b/inc/barcode.class.php
@@ -470,12 +470,10 @@ class PluginBarcodeBarcode {
             }
             foreach ($ids as $key) {
                $item->getFromDB($key);
-               if (key($ma->items) == 'Ticket') {
+               if (key($ma->items) == 'CommonITILObject') {
                   $codes[] = $item->getField('id');
-               } else {
-                  if ($item->isField('otherserial')) {
-                     $codes[] = $item->getField('otherserial');
-                  }
+               } else if ($item->isField('otherserial')) {
+                  $codes[] = $item->getField('otherserial');
                }
             }
             if (count($codes) > 0) {

--- a/inc/qrcode.class.php
+++ b/inc/qrcode.class.php
@@ -167,7 +167,7 @@ class PluginBarcodeQRcode {
       if (!$no_form_page) {
          echo '<tr>';
          echo '<td>';
-         echo __('Web page of the device')." : </td><td>";
+         echo __('Web page of the item')." : </td><td>";
          Dropdown::showYesNo("url", 1, -1, ['width' => '100']);
          echo '</td>';
          echo '</tr>';

--- a/inc/qrcode.class.php
+++ b/inc/qrcode.class.php
@@ -111,54 +111,93 @@ class PluginBarcodeQRcode {
    }
 
 
+   function showFormMassiveAction(MassiveAction $ma) {
 
-   function showFormMassiveAction() {
+      $fields       = [];
+      $no_form_page = true;
+
+      $itemtype = $ma->getItemtype(false);
+      if (is_a($itemtype, CommonDBTM::class, true)) {
+         /** @var CommonDBTM $item */
+         $item = new $itemtype();
+         $item->getEmpty();
+         $fields = array_keys($item->fields);
+         $no_form_page = $item->no_form_page;
+      }
 
       echo '<input type="hidden" name="type" value="QRcode" />';
       echo '<center>';
       echo '<table>';
-      echo '<tr>';
-      echo '<td>';
-      echo __('Serial number')." : </td><td>";
-      Dropdown::showYesNo("serialnumber", 1, -1, ['width' => '100']);
-      echo '</td>';
-      echo '</tr>';
-      echo '<tr>';
-      echo '<td>';
-      echo __('Inventory number')." : </td><td>";
-      Dropdown::showYesNo("inventorynumber", 1, -1, ['width' => '100']);
-      echo '</td>';
-      echo '</tr>';
+
+      if (in_array('serial', $fields)) {
+         echo '<tr>';
+         echo '<td>';
+         echo __('Serial number')." : </td><td>";
+         Dropdown::showYesNo("serialnumber", 1, -1, ['width' => '100']);
+         echo '</td>';
+         echo '</tr>';
+      } else {
+         echo Html::hidden('serialnumber', ['value' => 0]);
+      }
+
+      if (in_array('otherserial', $fields)) {
+         echo '<tr>';
+         echo '<td>';
+         echo __('Inventory number')." : </td><td>";
+         Dropdown::showYesNo("inventorynumber", 1, -1, ['width' => '100']);
+         echo '</td>';
+         echo '</tr>';
+      } else {
+         echo Html::hidden('inventorynumber', ['value' => 0]);
+      }
+
       echo '<tr>';
       echo '<td>';
       echo __('ID')." : </td><td>";
       Dropdown::showYesNo("id", 1, -1, ['width' => '100']);
       echo '</td>';
       echo '</tr>';
-      echo '<tr>';
-      echo '<td>';
-      echo __('UUID')." : </td><td>";
-      Dropdown::showYesNo("uuid", 1, -1, ['width' => '100']);
-      echo '</td>';
-      echo '</tr>';
-      echo '<tr>';
-      echo '<td>';
-      echo __('Name')." : </td><td>";
-      Dropdown::showYesNo("name", 1, -1, ['width' => '100']);
-      echo '</td>';
-      echo '</tr>';
-      echo '<tr>';
-      echo '<td>';
-      echo __('Web page of the device')." : </td><td>";
-      Dropdown::showYesNo("url", 1, -1, ['width' => '100']);
-      echo '</td>';
-      echo '</tr>';
+
+      if (in_array('uuid', $fields)) {
+         echo '<tr>';
+         echo '<td>';
+         echo __('UUID')." : </td><td>";
+         Dropdown::showYesNo("uuid", 1, -1, ['width' => '100']);
+         echo '</td>';
+         echo '</tr>';
+      } else {
+         echo Html::hidden('uuid', ['value' => 0]);
+      }
+
+      if (in_array('name', $fields)) {
+         echo '<tr>';
+         echo '<td>';
+         echo __('Name')." : </td><td>";
+         Dropdown::showYesNo("name", 1, -1, ['width' => '100']);
+         echo '</td>';
+         echo '</tr>';
+      } else {
+         echo Html::hidden('name', ['value' => 0]);
+      }
+
+      if (!$no_form_page) {
+         echo '<tr>';
+         echo '<td>';
+         echo __('Web page of the device')." : </td><td>";
+         Dropdown::showYesNo("url", 1, -1, ['width' => '100']);
+         echo '</td>';
+         echo '</tr>';
+      } else {
+         echo Html::hidden('url', ['value' => 0]);
+      }
+
       echo '<tr>';
       echo '<td>';
       echo __('Date QRcode')." (".date('Y-m-d').") : </td><td>";
       Dropdown::showYesNo("qrcodedate", 1, -1, ['width' => '100']);
       echo '</td>';
       echo '</tr>';
+
       echo '</table>';
       echo '<br/>';
 
@@ -185,7 +224,7 @@ class PluginBarcodeQRcode {
 
          case 'Generate':
             $pbQRcode = new self();
-            $pbQRcode->showFormMassiveAction();
+            $pbQRcode->showFormMassiveAction($ma);
             return true;
 
       }

--- a/inc/qrcode.class.php
+++ b/inc/qrcode.class.php
@@ -48,44 +48,28 @@ class PluginBarcodeQRcode {
    function generateQRcode($itemtype, $items_id, $rand, $number, $data) {
       global $CFG_GLPI;
 
+      /** @var CommonDBTM $item */
       $item = new $itemtype();
       $item->getFromDB($items_id);
+
       $a_content = [];
-      $have_content = false;
-      if ($data['serialnumber']) {
-         if ($item->fields['serial'] != '') {
-            $have_content = true;
-         }
+      if ($data['serialnumber'] && $item->fields['serial'] != '') {
          $a_content[] = 'Serial Number = '.$item->fields['serial'];
       }
-      if ($data['inventorynumber']) {
-         if ($item->fields['otherserial'] != '') {
-            $have_content = true;
-         }
+      if ($data['inventorynumber'] && $item->fields['inventorynumber'] != '') {
          $a_content[] = 'Inventory Number = '.$item->fields['otherserial'];
       }
-      if ($data['id']) {
-         if ($item->fields['id'] != '') {
-            $have_content = true;
-         }
+      if ($data['id'] && $item->fields['id'] != '') {
          $a_content[] = 'ID = '.$item->fields['id'];
       }
-      if (isset($data['uuid']) && $data['uuid']) {
-         if (isset($item->fields['uuid'])) {
-            if ($item->fields['uuid'] != '') {
-               $have_content = true;
-            }
-            $a_content[] = 'UUID = '.$item->fields['uuid'];
-         }
+      if ($data['uuid'] && $item->fields['uuid'] != '') {
+         $a_content[] = 'UUID = '.$item->fields['uuid'];
       }
-      if ($data['name']) {
-         if ($item->fields['name'] != '') {
-            $have_content = true;
-         }
+      if ($data['name'] && $item->fields['name'] != '') {
          $a_content[] = 'Name = '.$item->fields['name'];
       }
-      if ($data['url']) {
-         $a_content[] = 'URL = '.$CFG_GLPI["url_base"].Toolbox::getItemTypeFormURL($itemtype, false)."?id=".$items_id;
+      if ($data['url'] && !$item->no_form_page) {
+         $a_content[] = 'URL = '.$CFG_GLPI["url_base"].$itemtype::getFormURLWithID($items_id);
       }
       if ($data['qrcodedate']) {
          $a_content[] = 'QRcode date = '.date('Y-m-d');

--- a/inc/qrcode.class.php
+++ b/inc/qrcode.class.php
@@ -56,7 +56,7 @@ class PluginBarcodeQRcode {
       if ($data['serialnumber'] && $item->fields['serial'] != '') {
          $a_content[] = 'Serial Number = '.$item->fields['serial'];
       }
-      if ($data['inventorynumber'] && $item->fields['inventorynumber'] != '') {
+      if ($data['inventorynumber'] && $item->fields['otherserial'] != '') {
          $a_content[] = 'Inventory Number = '.$item->fields['otherserial'];
       }
       if ($data['id'] && $item->fields['id'] != '') {


### PR DESCRIPTION
I made this PR to give ability to generate bar and QR codes for any object that has required fields.

Bar codes will not be available for any item having a `otherserial` field, and for CommonITILObject types (in replacement of Ticket).

QR codes will be available for any item, as it can be generated using only the ID.

Replaces https://github.com/pluginsGLPI/barcode/pull/35