### PR TITLE
Remove calling to a parent that does not exists

### DIFF
--- a/inc/barcode.class.php
+++ b/inc/barcode.class.php
@@ -454,8 +454,7 @@ class PluginBarcodeBarcode {
 
 
    function getSpecificMassiveActions($checkitem = null) {
-      $actions = parent::getSpecificMassiveActions($checkitem);
-      return $actions;
+      return [];
    }
 
 
@@ -473,7 +472,7 @@ class PluginBarcodeBarcode {
             return true;
 
       }
-       return parent::showMassiveActionsSubForm($ma);
+      return false;
    }
 
 
@@ -524,7 +523,7 @@ class PluginBarcodeBarcode {
             return;
 
       }
-      parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
+      return;
    }
 
 }

--- a/inc/qrcode.class.php
+++ b/inc/qrcode.class.php
@@ -329,8 +329,7 @@ class PluginBarcodeQRcode {
 
 
    function getSpecificMassiveActions($checkitem = null) {
-      $actions = parent::getSpecificMassiveActions($checkitem);
-      return $actions;
+      return [];
    }
 
 
@@ -350,7 +349,7 @@ class PluginBarcodeQRcode {
             return true;
 
       }
-      return parent::showMassiveActionsSubForm($ma);
+      return false;
    }
 
 
@@ -415,7 +414,7 @@ class PluginBarcodeQRcode {
             return;
 
       }
-      parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
+      return;
    }
 
 


### PR DESCRIPTION
On PHP 7.4, following deprecation message is triggered when trying to use plugin massive actions:
`
PHP Deprecated function: Cannot use "parent" when current class scope has no parent in /var/www/glpi/plugins/barcode/inc/qrcode.class.php at line 332
PHP Deprecated function: Cannot use "parent" when current class scope has no parent in /var/www/glpi/plugins/barcode/inc/qrcode.class.php at line 353
PHP Deprecated function: Cannot use "parent" when current class scope has no parent in /var/www/glpi/plugins/barcode/inc/qrcode.class.php at line 418
`

Indeed, `PluginBarcodeBarcode` and `PluginBarcodeQRcode` have no parent class.
