### PR TITLE
Fix undefined displayData on barcode generation

### DIFF
--- a/inc/barcode.class.php
+++ b/inc/barcode.class.php
@@ -269,29 +269,26 @@ class PluginBarcodeBarcode {
       $size        = $p_params['size'];
       $orientation = $p_params['orientation'];
       $codes       = [];
-      $displayDataCollection=[];
+
+      $displayDataCollection = $p_params['displayData'] ?? [];
 
       if ($type == 'QRcode') {
          $codes = $p_params['codes'];
-         $displayDataCollection = $p_params['displayData'];
       } else {
          if (isset($p_params['code'])) {
             if (isset($p_params['nb']) AND $p_params['nb']>1) {
                $this->create($p_params['code'], $type, $ext);
                for ($i=1; $i<=$p_params['nb']; $i++) {
                   $codes[] = $p_params['code'];
-                  $displayDataCollection = $p_params['displayData'];
                }
             } else {
                if (!$this->create($p_params['code'], $type, $ext)) {
                   Session::addMessageAfterRedirect(__('The generation of some barcodes produced errors.', 'barcode'));
                }
                $codes[] = $p_params['code'];
-               $displayDataCollection = $p_params['displayData'];
             }
          } else if (isset($p_params['codes'])) {
             $codes = $p_params['codes'];
-            $displayDataCollection = $p_params['displayData'];
             foreach ($codes as $code) {
                if ($code != '') {
                   $this->create($code, $type, $ext);
@@ -345,7 +342,7 @@ class PluginBarcodeBarcode {
       $first=true;
       for ($ia = 0; $ia < count($codes); $ia++) {
          $code = $codes[$ia];
-         $displayData = $displayDataCollection[$ia];
+         $displayData = $displayDataCollection[$ia] ?? [];
          if ($first) {
             $x = $pdf->ez['leftMargin'];
             $y = $pdf->ez['pageHeight'] - $pdf->ez['topMargin'] - $height;


### PR DESCRIPTION
In #36, no `displayData` was added in barcode generation parameters. So when generation a barcode, following errors are trigerred.

I do not know if is is due to something missing in the PR or if it is normal (functionnal point of view). @xacobofg ?

```
[2019-11-08 10:31:33] glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in /var/www/glpi/inc/toolbox.class.php line 663
  *** PHP Notice(8): Undefined index: displayData
  Backtrace :
  plugins/barcode/inc/barcode.class.php:294          
  plugins/barcode/inc/barcode.class.php:512          PluginBarcodeBarcode->printPDF()
  inc/massiveaction.class.php:1027                   PluginBarcodeBarcode::processMassiveActionsForOneItemtype()
  inc/massiveaction.class.php:1006                   MassiveAction->processForSeveralItemtypes()
  front/massiveaction.php:59                         MassiveAction->process()
  {"user":"2@4028a755e155"} 
[2019-11-08 10:31:33] glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in /var/www/glpi/inc/toolbox.class.php line 663
  *** PHP Notice(8): Trying to access array offset on value of type null
  Backtrace :
  plugins/barcode/inc/barcode.class.php:348          
  plugins/barcode/inc/barcode.class.php:512          PluginBarcodeBarcode->printPDF()
  inc/massiveaction.class.php:1027                   PluginBarcodeBarcode::processMassiveActionsForOneItemtype()
  inc/massiveaction.class.php:1006                   MassiveAction->processForSeveralItemtypes()
  front/massiveaction.php:59                         MassiveAction->process()
  {"user":"2@4028a755e155","mem_usage":"0.002\", 10.19Mio)"} 
```
