### PR TITLE
Update rospdf/pdf-php to prevent warnings on PHP 7.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -390,20 +390,20 @@
         },
         {
             "name": "rospdf/pdf-php",
-            "version": "0.12.58",
+            "version": "0.12.60",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rospdf/pdf-php.git",
-                "reference": "5aa9b288999d107725e676fc53dbd1e211370bc0"
+                "reference": "61e48d6301ded75775897f285d5c90def0c3be04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rospdf/pdf-php/zipball/5aa9b288999d107725e676fc53dbd1e211370bc0",
-                "reference": "5aa9b288999d107725e676fc53dbd1e211370bc0",
+                "url": "https://api.github.com/repos/rospdf/pdf-php/zipball/61e48d6301ded75775897f285d5c90def0c3be04",
+                "reference": "61e48d6301ded75775897f285d5c90def0c3be04",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.6.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "3.7.38",
@@ -455,7 +455,7 @@
             ],
             "description": "The R&OS Pdf class supports the creation of PDF documents without any adiditional modules or extensions.",
             "homepage": "https://github.com/rospdf/pdf-php",
-            "time": "2019-10-16T08:43:43+00:00"
+            "time": "2020-02-10T17:50:04+00:00"
         }
     ],
     "packages-dev": [
@@ -1015,6 +1015,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
         {


### PR DESCRIPTION
Will prevent having following errors when plugin is activated.

```
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2386
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2387
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2388
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2389
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2390
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2391
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2407
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2408
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2409
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2410
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2411
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2412
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 3092
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 3098
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 3100
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 3101
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 3103
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 3104
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 3105
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTFsubset.php at line 494
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 927
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 930
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1106
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1118
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1119
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1130
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1131
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1146
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1147
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1148
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1149
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1182
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1197
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1198
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1199
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1200
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1225
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1226
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1257
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1257
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1292
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1306
PHP Deprecated function: Array and string offset access syntax with curly braces is deprecated in ./vendor/rospdf/pdf-php/src/include/TTF.php at line 1307
```