### PR TITLE
Fix(Dep): specify QRCode class

### DIFF
--- a/inc/qrcode.class.php
+++ b/inc/qrcode.class.php
@@ -43,6 +43,8 @@ if (!defined('GLPI_ROOT')) {
     die("Sorry. You can't access directly to this file");
 }
 
+require_once __DIR__ . '/../vendor/deltalab/phpqrcode/phpqrcode.php';
+
 class PluginBarcodeQRcode {
 
    function generateQRcode($itemtype, $items_id, $rand, $number, $data) {


### PR DESCRIPTION
**Issue with Barcode Plugin When PDF Plugin Is Installed Afterwards**

When the PDF plugin is installed **after** the Barcode plugin, an error occurs when attempting to generate a barcode via a massive action:

```
[2025-05-09 10:58:27] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Call to undefined method QRcode::png() in /home/stanislas/TECLIB/DEV/GLPI/10bugfixes/plugins/barcode/inc/qrcode.class.php at line 159
  Backtrace :
  plugins/barcode/inc/qrcode.class.php:381           PluginBarcodeQRcode->generateQRcode()
  src/MassiveAction.php:1425                         PluginBarcodeQRcode::processMassiveActionsForOneItemtype()
  src/MassiveAction.php:1403                         MassiveAction->processForSeveralItemtypes()
  front/massiveaction.php:62                         MassiveAction->process()
```

It appears that the Barcode plugin attempts to use the `QRcode` class from the `tecnickcom/tcpdf` library, which is loaded last and overrides the intended class.

Since `deltalab/phpqrcode` declare `QRcode` class without namespaces, it is not possible to explicitly define which one to use via a PHP `use` statement. The only reliable workaround is to enforce loading the correct class via a `require_once` directive that directly includes the intended file.

Should fix 

#135
#125
#110

